### PR TITLE
LG-43 Job Entity의 index 컬럼명을 변경한다

### DIFF
--- a/src/main/java/com/linkgem/domain/job/Job.java
+++ b/src/main/java/com/linkgem/domain/job/Job.java
@@ -23,5 +23,5 @@ public class Job extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    private Long index;
+    private Long ordering;
 }


### PR DESCRIPTION
## 작업사항
* Job Entity의 index 컬럼명을 ordering으로 수정한다
* index 나 order 은 DB 컬럼명으로 사용할 수 없다