### PR TITLE
LG- 36 링크 저장시 전체(잼박스 없음)에 저장되도록 로직 변경

### DIFF
--- a/src/main/java/com/linkgem/domain/link/LinkCreateServiceImpl.java
+++ b/src/main/java/com/linkgem/domain/link/LinkCreateServiceImpl.java
@@ -54,9 +54,6 @@ public class LinkCreateServiceImpl implements LinkCreateService {
             .openGraph(openGraph)
             .build();
 
-        gemBoxReader.findDefault(user.getId())
-            .ifPresent(link::updateGemBox);
-
         Link createdLink = linkStore.create(link);
 
         if (link.hasImageUrl()) {

--- a/src/main/java/com/linkgem/domain/user/UserInitializeServiceImpl.java
+++ b/src/main/java/com/linkgem/domain/user/UserInitializeServiceImpl.java
@@ -22,9 +22,6 @@ public class UserInitializeServiceImpl implements UserInitializeService {
 
         final Long userId = user.getId();
 
-        //기본 잼박스 생성
-        gemBoxService.create(GemBoxCommand.Create.createDefault(userId));
-
         //회원가입 환영 알림
         NotificationCommand.Create joinNotification = notificationCreateFactory.createJoinNotification(user);
         notificationCreate.create(joinNotification);


### PR DESCRIPTION
## 작업사항
- 링크 저장시 전체에 저장되도록 변경했습니다. 

---
지라가 따로 없는걸로 알고 있어서 일단 이전 pr 참고해서 이슈번호로 했습니다. 
- https://github.com/LinkGem/LinkGem-BE/issues/36