### PR TITLE
feat(#LG-39): 개별 잼박스 합치기(머지) API 추가

### DIFF
--- a/src/main/java/com/linkgem/application/GemBoxFacade.java
+++ b/src/main/java/com/linkgem/application/GemBoxFacade.java
@@ -1,15 +1,13 @@
 package com.linkgem.application;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
-
 import com.linkgem.domain.gembox.GemBoxCommand;
 import com.linkgem.domain.gembox.GemBoxInfo;
 import com.linkgem.domain.gembox.GemBoxQuery;
 import com.linkgem.domain.gembox.GemBoxService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
@@ -39,5 +37,9 @@ public class GemBoxFacade {
 
     public void putLinksToGembox(GemBoxCommand.PutLinksToGembox command) {
         gemBoxService.putLinksToGembox(command);
+    }
+
+    public void merge(GemBoxCommand.Merge command) {
+        gemBoxService.merge(command);
     }
 }

--- a/src/main/java/com/linkgem/domain/gembox/GemBoxCommand.java
+++ b/src/main/java/com/linkgem/domain/gembox/GemBoxCommand.java
@@ -1,11 +1,11 @@
 package com.linkgem.domain.gembox;
 
-import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 public class GemBoxCommand {
 
@@ -68,5 +68,18 @@ public class GemBoxCommand {
         private Long userId;
         private Long gemBoxId;
         private List<Long> linkIds;
+    }
+
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    public static class Merge {
+        private Long userId;
+        private Long targetId;
+        private Long sourceId;
+
+        public static Merge of(Long userId, Long targetId, Long sourceId) {
+            return new Merge(userId, targetId, sourceId);
+        }
     }
 }

--- a/src/main/java/com/linkgem/domain/gembox/GemBoxService.java
+++ b/src/main/java/com/linkgem/domain/gembox/GemBoxService.java
@@ -1,9 +1,9 @@
 package com.linkgem.domain.gembox;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface GemBoxService {
 
@@ -22,4 +22,6 @@ public interface GemBoxService {
     void deleteAllByUserId(Long userId);
 
     void putLinksToGembox(GemBoxCommand.PutLinksToGembox command);
+
+    void merge(GemBoxCommand.Merge command);
 }

--- a/src/main/java/com/linkgem/presentation/gembox/GemBoxApiController.java
+++ b/src/main/java/com/linkgem/presentation/gembox/GemBoxApiController.java
@@ -1,20 +1,5 @@
 package com.linkgem.presentation.gembox;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.linkgem.application.GemBoxFacade;
 import com.linkgem.domain.common.Pages;
 import com.linkgem.domain.gembox.GemBoxCommand;
@@ -24,11 +9,17 @@ import com.linkgem.presentation.common.CommonResponse;
 import com.linkgem.presentation.common.UserAuthenticationProvider;
 import com.linkgem.presentation.gembox.dto.GemBoxRequest;
 import com.linkgem.presentation.gembox.dto.GemBoxResponse;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 @Api(tags = "잼박스")
 @RequiredArgsConstructor
@@ -132,4 +123,19 @@ public class GemBoxApiController {
         gemBoxFacade.putLinksToGembox(command);
         return ResponseEntity.noContent().build();
     }
+
+    @ApiOperation(value = "선택 된 잼박스를 합칠 잼 박스에 넣는다.", notes = "개별 잼 박스를 합친다.")
+    @PatchMapping(value = "/{targetId}/merge")
+    public ResponseEntity<Void> mergeGemBox(
+        HttpServletRequest httpServletRequest,
+        @ApiParam(value = "선택 된 잼박스 고유 아이디", example = "1")  @PathVariable Long targetId,
+        @ApiParam(value = "합칠 잼박스 고유 아이디", example = "1") @RequestParam Long sourceId
+    ) {
+
+        Long userId = UserAuthenticationProvider.provider(httpServletRequest);
+        gemBoxFacade.merge(GemBoxCommand.Merge.of(userId, targetId, sourceId));
+
+        return ResponseEntity.noContent().build();
+    }
+
 }


### PR DESCRIPTION
## 이슈 내용

- 잼박스 단일 합치기 API 개발
<img width="546" alt="image" src="https://github.com/LinkGem/LinkGem-BE/assets/74949294/34c9afc6-ef1d-4612-bc71-fad19c937f7f">

## ToDo

- [x] 선택 된 잼박스에 있던 링크를 합칠 잼박스로 이동
- [x] 선택 된 잼박스 삭제
